### PR TITLE
bump moped to fix vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
       moped (~> 1.4)
       origin (~> 1.0)
       tzinfo (~> 0.3.29)
-    moped (1.5.2)
+    moped (1.5.3)
     multi_json (1.11.0)
     multipart-post (2.0.0)
     newrelic_rpm (3.11.2.286)
@@ -130,3 +130,6 @@ DEPENDENCIES
   thin
   webmock
   zendesk_api
+
+BUNDLED WITH
+   1.10.2


### PR DESCRIPTION
@steved 

```
zendesk_api_playground
bundle-audit --ignore OSVDB-103151 OSVDB-108664 OSVDB-108665 OSVDB-117461 OSVDB-120415
Name: moped
Version: 1.5.2
Advisory: CVE-2015-4410
Criticality: Unknown
URL: http://sakurity.com/blog/2015/06/04/mongo_ruby_regexp.html
Title: Data Injection Vulnerability in moped Rubygem
Solution: upgrade to ~> 1.5.3, >= 2.0.5
```
### Risks
- None
