### PR TITLE
bump rack to avoid CVE-2015-3225

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ GEM
     multipart-post (2.0.0)
     newrelic_rpm (3.11.2.286)
     origin (1.1.0)
-    rack (1.6.0)
+    rack (1.6.4)
     rack-protection (1.5.3)
       rack
     rack-ssl-enforcer (0.2.8)
@@ -132,4 +132,4 @@ DEPENDENCIES
   zendesk_api
 
 BUNDLED WITH
-   1.10.2
+   1.10.6


### PR DESCRIPTION
@steved 

```
Name: rack
Version: 1.6.0
Advisory: CVE-2015-3225
Criticality: Unknown
URL: https://groups.google.com/forum/#!topic/ruby-security-ann/gcUbICUmKMc
Title: Potential Denial of Service Vulnerability in Rack
Solution: upgrade to >= 1.6.2, ~> 1.5.4, ~> 1.4.6
```
### Risks
- None
